### PR TITLE
Update the arena diagram for Scavengers

### DIFF
--- a/fig-arena.svg
+++ b/fig-arena.svg
@@ -141,6 +141,55 @@
       <use xlink:href="#token" transform="translate(2.1 0.9)"/>
       <use xlink:href="#token" transform="translate(3 0.7)"/>
     </g>
+    <g id="token-dimensions" transform="translate(8.4 8.4)">
+      <!-- nearest the corner -->
+      <g class="dimension" transform="translate(-0.7 -1.4) translate(0 -0.2)">
+        <line x1="-0.7" y1="0" x2="0.7" y2="0"/>
+        <text x="0" y="-0.1" class="above">1400±20mm</text>
+      </g>
+      <g class="dimension" transform="translate(-1.4 -0.7) translate(0.2 0)">
+        <line x1="0" y1="0.7" x2="0" y2="-0.7"/>
+        <text x="0" y="-0.45" class="right">1400±20mm</text>
+      </g>
+      <!-- heading leftwards -->
+      <line x1="0" y1="0.1" x2="0" y2="-0.9" class="dimension-guide" transform="translate(-2.1 0)"/>
+      <g class="dimension" transform="translate(-1.05 0.1)">
+        <line x1="-1.05" y1="0" x2="1.05" y2="0"/>
+        <text x="0" y="0.2" class="above">2100±20mm</text>
+      </g>
+      <g class="dimension" transform="translate(-2.1 -0.45) translate(-0.2 0)">
+        <line x1="0" y1="0.45" x2="0" y2="-0.45"/>
+        <text x="0" y="-0.5" class="left">900±20mm</text>
+      </g>
+      <line x1="0" y1="0.45" x2="0" y2="-0.7" class="dimension-guide" transform="translate(-3 0)"/>
+      <g class="dimension" transform="translate(-1.5 0.45)">
+        <line x1="-1.5" y1="0" x2="1.5" y2="0"/>
+        <text x="0" y="0.2" class="above">3000±20mm</text>
+      </g>
+      <g class="dimension" transform="translate(-3 -0.35) translate(-0.2 0)">
+        <line x1="0" y1="0.35" x2="0" y2="-0.35"/>
+        <text x="-0.05" y="0" class="left">700±20mm</text>
+      </g>
+      <!-- heading upwards -->
+      <line x1="0.1" y1="0" x2="-0.9" y2="0" class="dimension-guide" transform="translate(0 -2.1)"/>
+      <g class="dimension" transform="translate(0.1 -1.05)">
+        <line x1="0" y1="-1.05" x2="0" y2="1.05"/>
+        <text x="0" y="-0.075" class="left-rotated" transform="rotate(90)">2100±20mm</text>
+      </g>
+      <g class="dimension" transform="translate(-0.45 -2.1) translate(0 -0.2)">
+        <line x1="0.45" y1="0" x2="-0.45" y2="0"/>
+        <text x="-0.1" y="-0.1" class="above">900±20mm</text>
+      </g>
+      <line x1="0.45" y1="0" x2="-0.7" y2="0" class="dimension-guide" transform="translate(0 -3)"/>
+      <g class="dimension" transform="translate(0.45 -1.5)">
+        <line x1="0" y1="-1.5" x2="0" y2="1.5"/>
+        <text x="0" y="-0.075" class="left-rotated" transform="rotate(90)">3000±20mm</text>
+      </g>
+      <g class="dimension" transform="translate(-0.35 -3) translate(0 -0.2)">
+        <line x1="0.35" y1="0" x2="-0.35" y2="0"/>
+        <text x="-0.2" y="-0.1" class="above">700±20mm</text>
+      </g>
+    </g>
     <rect width="1.22"
           height="1.22"
           y="-0.61"
@@ -220,13 +269,13 @@
       <use class="corner corner-1" xlink:href="#starting-area" transform="rotate(90 4.2 4.2)"/>
       <use class="corner corner-2" xlink:href="#starting-area" transform="rotate(180 4.2 4.2)"/>
       <use class="corner corner-3" xlink:href="#starting-area" transform="rotate(270 4.2 4.2)"/>
-      <g class="dimension" transform="translate(0 8.4) translate(0 0.12)">
+      <g class="dimension" transform="translate(8.4 0) translate(-1 1.12)">
         <line x1="0" y1="0" x2="1" y2="0"/>
-        <text x="0.5" y="0.2" class="above">1000±20mm</text>
+        <text x="0.4" y="0.2" class="above">1000±20mm</text>
       </g>
-      <g class="dimension" transform="translate(0 8.4) translate(1.12 -1)">
+      <g class="dimension" transform="translate(8.4 0) translate(-1.12 0)">
         <line x1="0" y1="1" x2="0" y2="0"/>
-        <text x="0.05" y="0.55" class="right">1000±20mm</text>
+        <text x="-0.05" y="0.55" class="left">1000±20mm</text>
       </g>
       <!-- raised areas -->
       <use xlink:href="#side-platform" transform="translate(0 4.2)"/>
@@ -261,6 +310,7 @@
       <use xlink:href="#tokens" transform="rotate(90 4.2 4.2)"/>
       <use xlink:href="#tokens" transform="rotate(180 4.2 4.2)"/>
       <use xlink:href="#tokens" transform="rotate(270 4.2 4.2)"/>
+      <use xlink:href="#token-dimensions"/>
       <!-- arena wall -->
       <rect width="8.4"
             height="8.4"
@@ -277,7 +327,7 @@
       </g>
     </g>
     <g id="legend"
-       transform="translate(2.2 10.6)">
+       transform="translate(2.2 10.8)">
       <g transform="translate(0 0)">
         <use fill="none" xlink:href="#starting-area" transform="scale(0.5) translate(-0.6 -0.6)"/>
         <text x="0.5" y="0" class="legend-label">Robot starting area</text>


### PR DESCRIPTION
![fig-arena](https://user-images.githubusercontent.com/336212/62825793-3257e900-bba9-11e9-8e69-7a2ecb286a8e.png)

### Token locations

I'm now proposing the following co-ordinates (note that this is different to what I put on #6):

- 0.7 3
- 0.9 2.1
- 1.4 1.4
- 2.1 0.9
- 3 0.7

### TODO

- [x] pin down the actual dimensions we're using for the game
- [ ] fix the dimensions to have the right numbers (multiples of 1.22m, rather than 1.2m)
- [x] fix the tolerances to be sensible (and match the text in the rules)
- [x] confirm the token locations
- [x] work out if the token location dimensions can fit on the diagram; if so then add them
     ~my plan here would be to move the starting area dimensions to the bottom right (from bottom left) and then use the bottom left corner to specify the location dimensions~
