### PR TITLE
Rework scoring wording

### DIFF
--- a/game-rules.tex
+++ b/game-rules.tex
@@ -17,14 +17,14 @@
     \end{enumerate}
   \item Tokens are considered to be `in the control of' a robot if and only if:
     \begin{enumerate}
-      \item Fewer than 3 corners are in contact with the floor.
-      \item When the robot is lifted, the token remains held by the robot.
+      \item fewer than 3 corners are in contact with the floor, and
+      \item when the robot is lifted, the token remains held by the robot.
     \end{enumerate}
   \item A token is considered to be `in' a zone if either:
     \begin{enumerate}
-      \item at least three corners of the token are in contact with the floor.
+      \item at least three corners of the token are in contact with the floor, or
       \item the token is in contact only with the floor of the zone and any part
-            of the raised area within the zone.
+            of the raised area within the zone, or
       \item the token is in contact only with other tokens which are `in' the zone.
             In the case where several such tokens are in mutual contact (and not in
             contact with anything else), all those tokens are `in' the zone.
@@ -32,8 +32,8 @@
   \item A token is considered to be `on' the raised area if either:
     \begin{enumerate}
       \item at least three corners of the token are in contact with the top
-            surface of the raised area.
-      \item the token is in contact only with the top surface of the raised area.
+            surface of the raised area, or
+      \item the token is in contact only with the top surface of the raised area, or
       \item the token is in contact only with other tokens which are `on' the raised area.
             In the case where several such tokens are in mutual contact (and not in
             contact with anything else), all those tokens are `on' the raised area.


### PR DESCRIPTION
This reworks the scoring wording for clarity. It's now quite verbose, though I think covers all the cases we can think of.

The part I'm least sure about is whether it's clear enough that being on the raised area needs to also be within the area of your zone. I'm hoping that this is covered by the new introductory rule, but feedback on this would be good.

Review by commit is highly recommended.

This is based on https://github.com/trickeydan/smallpeice-rules/pull/3 for minimal diff, but should probably be merged separately and _after_ that has already been merged.