### PR TITLE
Scoring zone sizes

### DIFF
--- a/specs.tex
+++ b/specs.tex
@@ -14,13 +14,14 @@
         figure is to scale.
   \item The outer walls of the arena are at least \SI{600}{mm} high, and the
         interior surface is white plastic-coated hardboard.
-  \item The raised area is \SI{2.4}{m} $\times$ \SI{2.4}{m} $\pm$ \SI{100}{mm},
-        with a height of \SI{180}{mm} $\pm$ \SI{10}{mm}.
-  \item The scoring zones extend a further \SI{2.4}{m} $\times$ \SI{2.4}{m} $\pm$ \SI{100}{mm}
-        from the raised area, resulting in a total size of \SI{4.8}{m} $\times$ \SI{4.8}{m} $\pm$ \SI{200}{mm}.
+  \item Each of scoring zones is \SI{2.4}{m} $\times$ \SI{2.4}{m} $\pm$ \SI{100}{mm},
+        resulting in a total size of \SI{4.8}{m} $\times$ \SI{4.8}{m} $\pm$ \SI{200}{mm}
+        for the four scoring zones.
   \item Scoring zones are bounded by metallic tape around the perimeter
         and internal boundaries. The inside edge of the tape marks the outside
         edge of the scoring zone.
+  \item The raised area in the centre of the arena is \SI{2.4}{m} $\times$ \SI{2.4}{m} $\pm$ \SI{100}{mm},
+        with a height of \SI{180}{mm} $\pm$ \SI{10}{mm}.
   \item At the cardinal points of the arena are \SI{1.2}{m} $\times$ \SI{1.2}{m} $\pm$ \SI{100}{mm} walls,
         raised at least \SI{180}{mm} $\pm$ \SI{10}{mm}.
   \item Scoring zones for teams are offset 90\degree{} anti-clockwise, such


### PR DESCRIPTION
This fixes some minor bugs in the arena description and then clarifies the interaction between the scoring zones and the raised area. We don't actually mention exactly where the raised area is relative to the zones, though that should be covered by the diagram.

Suggest review by commit