### PR TITLE
Token positions

### DIFF
--- a/specs.tex
+++ b/specs.tex
@@ -43,4 +43,11 @@
   \item The tokens are cuboids with side length \SI{250}{mm} $\pm$ \SI{10}{mm}.
   \item Each face of each token is bordered by \SI{10}{mm} $\pm$ \SI{2}{mm} of
         copper conductive tape.
+  \item There are 20 possible starting positions for tokens in the arena. These
+        are arranged as indicated in Figure~\ref{fig:arena}.
+  \item At the start of each match each quadrant four of the starting positions
+        in each quadrant will be occupied. The position nearest the starting
+        area of each quadrant will always be occupied.
+  \item While the token starting positions are rotationally symmetrical, the
+        pattern of which are occupied in any given match may not be.
 \end{enumerate}


### PR DESCRIPTION
This reworks some minor bugs in the tokens section and then outlines what I believe is the agreed description of where the tokens are going to be.

This intentionally omits the measurements, as I expect that would be too complicated to describe. I am instead intending to include that only on the diagram.

For reference though here are the proposed locations, as co-ordinates from the arena corner:
- 1m, 3m
- 1.2m, 2m
- 1.45m, 1.45m
- 2m, 1.2m
- 3m, 1m

I'm probably going to go with ± 50 mm as the tolerance on the token positions.

Suggest review by commit