### PR TITLE
Remove rule about finishing ontop of the raised area

### DIFF
--- a/game-rules.tex
+++ b/game-rules.tex
@@ -38,8 +38,6 @@
             In the case where several such tokens are in mutual contact (and not in
             contact with anything else), all those tokens are `on' the raised area.
     \end{enumerate}
-  \item If, at the end of the match, a robot is anywhere on the top of the
-        raised area then they earn an additional 30 points.
   \item During a match, a robot may move or interact with any token in the arena.
   \item Participating teams must present their robots to match officials before
         the start of matches, as regulated by the match officials. Non-compliant


### PR DESCRIPTION
Suggested by @Tyler-Ward, and I agree.

This is an incredibly difficult, functionally impossible task for teams to do anyway. But encouraging them to do this may lead to them attempting to ram into the arena, or focusing too much on trying to climb (and no doubt failing), and not enough time focusing on the rest of the game.