### PR TITLE
Allow concurrent PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Make the concurrency key per-branch so that PR builds don't stamp on each other.