### PR TITLE
Penalise knocking over cans

### DIFF
--- a/src/fig-arena.svg
+++ b/src/fig-arena.svg
@@ -191,8 +191,8 @@
       <use xlink:href="#can" transform="translate(4.18 1.22)" class="can"/>
       <use xlink:href="#can" transform="translate(1.22 1.78)" class="can"/>
       <use xlink:href="#can" transform="translate(2.24 2.1)" class="can"/>
-      <use xlink:href="#can" transform="translate(0.37 2.77)" class="can"/>
-      <use xlink:href="#can" transform="translate(1.11 2.77)" class="can"/>
+      <use xlink:href="#can" transform="translate(0.37 2.81)" class="can"/>
+      <use xlink:href="#can" transform="translate(1.11 2.62)" class="can"/>
 
       <!-- Inner wall -->
       <rect width="1.22"
@@ -307,11 +307,11 @@
     <line x1="4.18" y1="1.22" x2="5.4" y2="1.22" class="dimension" />
 
     <line x1="5.03" y1="2.77" x2="5.4" y2="2.77" class="dimension" />
-    <line x1="5.03" y1="2.77" x2="5.03" y2="2.7" class="dimension-guide" />
+    <line x1="5.03" y1="2.77" x2="5.03" y2="2.68" class="dimension-guide" />
     <text class="dimension" y="2.9" x="5.05">370±100mm</text>
 
     <line x1="3.92" y1="2.5" x2="4.29" y2="2.5" class="dimension" />
-    <line x1="4.29" y1="2.5" x2="4.29" y2="2.56" class="dimension-guide" />
+    <line x1="4.29" y1="2.5" x2="4.29" y2="2.7" class="dimension-guide" />
     <text class="dimension" y="2.4" x="4.26">370±100mm</text>
 
     <line x1="0" y1="5.5" x2="5.4" y2="5.5" class="dimension" />

--- a/src/index.html
+++ b/src/index.html
@@ -58,13 +58,15 @@
           Game points will be awarded as follows:
           <ol type="a">
             <li>
-              <strong>1</strong> point is awarded each time a robot crosses a scoring line in the anti-clockwise direction.
+              <strong>3</strong> points are awarded each time a robot crosses a scoring line in the anti-clockwise direction.
             <li>
-              At the end of each lap - defined as every subsequent forward crossing of the scoring line immediately in front of the robot's starting area - a robot is awarded an additional <strong>4</strong> points for the crossing.
+              At the end of each lap - defined as every subsequent forward crossing of the scoring line immediately in front of the robot's starting area - a robot is awarded an additional <strong>8</strong> points for the crossing.
             <li>
               A robot is deemed to have passed a scoring line when the whole robot passes the line.
             <li>
               If a robot passes backwards (i.e: clockwise) over any scoring line it must "undo" these before any further forwards line crossings will be counted.
+            <li>
+              If a robot knocks over a can since its last forward scoring line crossing, the next crossing is only worth <strong>1</strong> point.
           </ol>
         <li>
           At the end of the match the robot with the most points wins.

--- a/src/index.html
+++ b/src/index.html
@@ -66,7 +66,7 @@
             <li>
               If a robot passes backwards (i.e: clockwise) over any scoring line it must "undo" these before any further forwards line crossings will be counted.
             <li>
-              If a robot doesn't knock over a can since its last forward scoring line crossing, the crossing is worth an additional <strong>1</strong> point.
+              If a robot avoids knocking over any cans since its last forward scoring line crossing, the crossing is worth an additional <strong>1</strong> point.
           </ol>
         <li>
           At the end of the match the robot with the most points wins.

--- a/src/index.html
+++ b/src/index.html
@@ -60,7 +60,7 @@
             <li>
               <strong>2</strong> points are awarded each time a robot crosses a scoring line in the anti-clockwise direction.
             <li>
-              At the end of each lap - defined as every subsequent forward crossing of the scoring line immediately in front of the robot's starting area - a robot is awarded an additional <strong>8</strong> points for the crossing.
+              At the end of each lap - defined as every subsequent forward crossing of the scoring line immediately in front of the robot's starting area - a robot is awarded an additional <strong>4</strong> points for the crossing.
             <li>
               A robot is deemed to have passed a scoring line when the whole robot passes the line.
             <li>

--- a/src/index.html
+++ b/src/index.html
@@ -58,7 +58,7 @@
           Game points will be awarded as follows:
           <ol type="a">
             <li>
-              <strong>3</strong> points are awarded each time a robot crosses a scoring line in the anti-clockwise direction.
+              <strong>2</strong> points are awarded each time a robot crosses a scoring line in the anti-clockwise direction.
             <li>
               At the end of each lap - defined as every subsequent forward crossing of the scoring line immediately in front of the robot's starting area - a robot is awarded an additional <strong>8</strong> points for the crossing.
             <li>
@@ -66,7 +66,7 @@
             <li>
               If a robot passes backwards (i.e: clockwise) over any scoring line it must "undo" these before any further forwards line crossings will be counted.
             <li>
-              If a robot knocks over a can since its last forward scoring line crossing, the next crossing is only worth <strong>1</strong> point.
+              If a robot doesn't knock over a can since its last forward scoring line crossing, the crossing is worth an additional <strong>1</strong> point.
           </ol>
         <li>
           At the end of the match the robot with the most points wins.


### PR DESCRIPTION
Cans are likely light enough to not be much of an obstacle for robots and won't knock them off course.

Instead, force robots to avoid them by attaching points to it.